### PR TITLE
Doc: highlight that setBfree -H is a long and great doc !

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ An excellent tutorial to get started with JACK can be found on the
 [libremusicproduction](http://libremusicproduction.com/articles/demystifying-jack-%E2%80%93-beginners-guide-getting-started-jack)
 website.
 
+Detailed documentation
+----------------------
+
+For a detailed documentation, run:
+
+	setBfree -H
 
 Internal Signal Flow
 --------------------

--- a/b_synth/ui.c
+++ b/b_synth/ui.c
@@ -21,7 +21,7 @@
 #define _GNU_SOURCE
 #endif
 
-#define ANIMSTEPS (35)
+#define ANIMSTEPS (2)
 
 #ifdef ANIMSTEPS
 #define ANDNOANIM && ui->openanim == 0


### PR DESCRIPTION
Hi, I'm using setBfree for a while now, and I always scratched my head wondering: where is the doc ?? Just "discovered" `setBfree -H` to be a more more detailed doc than `setBfreeUI -h` (and I didn't noticed that little line inside `setBfree -h` telling me that there's actually a great doc).
This great doc should be highlighted in readme !