### PR TITLE
Fix sprintf buffer overflow warnings by GCC

### DIFF
--- a/src/pgmParser.c
+++ b/src/pgmParser.c
@@ -45,9 +45,9 @@
 
 /* Buffer sizes */
 
-#define STRINGBUFFERSZ 256
-#define SYMBOLSIZE STRINGBUFFERSZ
-#define VALUESIZE STRINGBUFFERSZ
+#define STRINGBUFFERSZ 280
+#define SYMBOLSIZE 256
+#define VALUESIZE 256
 
 typedef int B3TokenType;
 typedef int ParseReturnCode;


### PR DESCRIPTION
Output of compilation log by gcc using fortify source and fedora compilation flags:

```
../src/pgmParser.c:282:39: warning: '%s' directive writing up to 255 bytes into a region of size 236 [-Wformat-overflow=]
    sprintf (msg, "'=' expected after '%s'", symbol);
                                       ^~    ~~~~~~
In file included from /usr/include/stdio.h:873,
                 from ../src/pgmParser.c:24:
/usr/include/bits/stdio2.h:36:10: note: '__builtin___sprintf_chk' output between 22 and 277 bytes into a destination of size 256
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/pgmParser.c:287:41: warning: '%s' directive writing up to 255 bytes into a region of size 234 [-Wformat-overflow=]
    sprintf (msg, "bad expression after '%s='", symbol);
                                         ^~     ~~~~~~
In file included from /usr/include/stdio.h:873,
                 from ../src/pgmParser.c:24:
/usr/include/bits/stdio2.h:36:10: note: '__builtin___sprintf_chk' output between 25 and 280 bytes into a destination of size 256
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Using snprintf would be even better IMHO