### PR TITLE
(re-)adds desktop files

### DIFF
--- a/resources/setbfree.desktop
+++ b/resources/setbfree.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=setBfree
+GenericName=DSP tonewheel organ
+GenericName[fr]=orgue à roues phoniques
+Comment=MIDI-controlled, software synthesizer for JACK and LV2
+Comment[fr]=Synthétiseur logiciel contrôlé par MIDI, pour JACK et LV2
+Icon=setBfree
+Exec=setBfreeUI
+Terminal=false
+Categories=AudioVideo;Audio;

--- a/resources/x42-whirl.desktop
+++ b/resources/x42-whirl.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=x42-whirl
+GenericName=setBfree Whirl Speaker
+GenericName[fr]=Haut parleur rotatif setBfree
+Comment=Leslie speaker emulation as JACK client
+Comment[fr]=Émulation de haut parleur Leslie en tant que client JACK
+Icon=x42-whirl
+Exec=x42-whirl
+Terminal=false
+Categories=AudioVideo;Audio;


### PR DESCRIPTION
Since they were erased while removing the debian packaging folder, but are still useful to be shipped upstream (here).
