### PR TITLE
Add Nord Electro 5 config file

### DIFF
--- a/cfg/electro5d.cfg
+++ b/cfg/electro5d.cfg
@@ -1,0 +1,36 @@
+# MIDI mappings for the Nord Electro 5
+
+midi.port=Nord Electro 5*
+
+midi.controller.reset=1
+
+# The Electro only has one set of drawbars. The CC values range from 0 (drawbar
+# pushed all the way in) to 127 (pulled fully out), so need to be inverted to
+# map to setBfree's interpretation.
+midi.controller.upper.16=upper.drawbar16-
+midi.controller.upper.17=upper.drawbar513-
+midi.controller.upper.18=upper.drawbar8-
+midi.controller.upper.19=upper.drawbar4-
+midi.controller.upper.20=upper.drawbar223-
+midi.controller.upper.21=upper.drawbar2-
+midi.controller.upper.22=upper.drawbar135-
+midi.controller.upper.23=upper.drawbar113-
+midi.controller.upper.24=upper.drawbar1-
+
+# Percussion controls. The Nord uses one button whose different CC values map
+# to different combinations of "soft" and "fast" - this can not currently be
+# interpreted by setBfree, so for now just enable on/off and 2nd/3rd harmonic
+# controls.
+midi.controller.upper.87=percussion.enable
+midi.controller.upper.95=percussion.harmonic
+
+midi.controller.upper.85=vibrato.upper
+
+midi.controller.upper.11=swellpedal1
+
+# This is the "DRIVE/COMP" control. We can't use the buttons on that section to
+# enable overdrive though, because they must be switched on and set to "ROTARY"
+# to allow the rotary speed controls to be enabled on the keyboard.
+midi.controller.upper.111=overdrive.character
+
+midi.controller.upper.102=reverb.mix


### PR DESCRIPTION
Add a config file containing the CC mappings which are compatible with
setBfree's existing control functions. Some features do not map
precisely to how setBfree interprets the control codes, for example the
Rotary controls - support for this will be implemented in a subsequent
commit.