### PR TITLE
fix: add -lGL to UILIBS for non-static unix LV2 builds

### DIFF
--- a/common.mak
+++ b/common.mak
@@ -167,7 +167,7 @@ ifeq ($(LV2AVAIL)$(HAVE_UI)$(HAVE_IDLE), yesyesyes)
         UILIBS+=`pkg-config --variable=libdir ftgl`/libftgl.a `pkg-config --variable=libdir ftgl`/libfreetype.a
         UILIBS+=`pkg-config --libs zlib`
       else
-        UILIBS+=`pkg-config --libs glu ftgl`
+        UILIBS+=`pkg-config --libs glu gl ftgl`
       endif
       UICFLAGS+=-DFONTFILE=\"$(FONTFILE)\"
     endif


### PR DESCRIPTION
Otherwise I get `undefined reference to symbol 'glXSwapBuffers'` when linking `b_synth` UI:

```
cc -D_FORTIFY_SOURCE=2 -march=native -O2 -pipe -fstack-protector-strong -fno-plt -fPIC -DVERSION="\"0.8.11-5\"" -DHAVE_LV2_1_8 -DHAVE_MEMSTREAM `pkg-config --cflags glu` -I../src -I../b_overdrive -I../b_reverb -I../b_whirl -I../b_synth/ `pkg-config --cflags lv2` -DLV2SYNTH -DREQUIRE_UI -std=c99 -I.. -DFONTFILE=\"/usr/share/fonts/TTF/DejaVuSans-Bold.ttf\" `pkg-config --cflags freetype2` `pkg-config --cflags ftgl` -DHAVE_FTGL -DUINQHACK=Sbf `pkg-config  --cflags liblo` -DHAVE_LIBLO  \
	-pthread \
	-DXTERNAL_UI -DJACK_AUTOCONNECT=15 \
	-DAPPNAME="\"setBfree\"" \
	-DJACK_DESCRIPT=\"/home/chris/work/setBfree/ui/desc.h\" \
	-o setBfreeUI \
	/home/chris/work/setBfree/robtk/jackwrap.c   \
	../src/midi.c ../src/cfgParser.c ../src/program.c ../src/vibrato.c ../src/state.c ../src/tonegen.c ../src/pgmParser.c ../src/memstream.c ../src/midnam.c ../b_whirl/eqcomp.c ../b_whirl/whirl.c ../b_overdrive/overdrive.c ../b_reverb/reverb.c  ../b_synth/lv2.c ../b_synth/ui.c \
	-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now ../pugl/pugl_x11.c -lX11 `pkg-config --libs glu ftgl` -ldl `pkg-config --libs jack` `pkg-config  --libs liblo` -lrt  \
	-lm
/home/chris/work/setBfree/robtk/jackwrap.c:271:1: Warnung: »LV2_URI_Map_Callback_Data« ist veraltet [-Wdeprecated-declarations]
  271 | static uint32_t uri_to_id (LV2_URI_Map_Callback_Data callback_data, const char* uri);
      | ^~~~~~
/home/chris/work/setBfree/robtk/jackwrap.c:821:1: Warnung: »LV2_URI_Map_Callback_Data« ist veraltet [-Wdeprecated-declarations]
  821 | uri_to_id (LV2_URI_Map_Callback_Data callback_data, const char* uri)
      | ^~~~~~~~~
/home/chris/work/setBfree/robtk/jackwrap.c: In Funktion »main«:
/home/chris/work/setBfree/robtk/jackwrap.c:1671:23: Warnung: Der Rückgabewert von »system«, der mit dem Attribut »warn_unused_result« deklariert wurde, wird ignoriert [-Wunused-result]
 1671 |                 (void)system ("xmessage -button ok -center \"Cannot connect to JACK.\nPlease start the JACK Server first.\" &");
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/ld: /home/chris/tmp/ccC5DFll.o: undefined reference to symbol 'glXSwapBuffers'
/usr/bin/ld: /usr/lib/libGL.so.1: error adding symbols: DSO missing from command line
```

