### PR TITLE
Register Leslie/Whirl parameters in initRunningConfig for proper LV2 state report

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -278,4 +278,12 @@ initRunningConfig (void* t, void* mcfg)
 	notifyControlChangeByName (mcfg, "reverb.mix", 127 * .1);
 	notifyControlChangeByName (mcfg, "swellpedal1", 127);
 	notifyControlChangeByName (mcfg, "rotary.speed-select", 4 * 15);
+
+	notifyControlChangeByName (mcfg, "rotary.speed-preset", 21);
+	notifyControlChangeByName (mcfg, "whirl.horn.brakepos", 0);
+	notifyControlChangeByName (mcfg, "whirl.drum.brakepos", 0);
+	notifyControlChangeByName (mcfg, "whirl.horn.acceleration", 12);
+	notifyControlChangeByName (mcfg, "whirl.horn.deceleration", 25);
+	notifyControlChangeByName (mcfg, "whirl.drum.acceleration", 58);
+	notifyControlChangeByName (mcfg, "whirl.drum.deceleration", 19);
 }


### PR DESCRIPTION
I am developing a prototypical Android Oboe Wrapper for the LV2 plugin version and came to the issue that not all params can be read out. Here is what i patched locally, maybe you want to have a look to add this or similar to mainline:

Whirl and rotary parameters were not initialized via notifyControlChangeByName() in initRunningConfig(), meaning the LV2 host could not read their initial values.
So i added them missing ones and tried to calculate the correct value looking at b_whirl/whirl.c for each parameters formula.
So values might be off/wrong, for me it sounded rightish but i am no real B3 organ player so I can't gurantee it being correct...