### PR TITLE
Jack Audio Direct Out before Whirl

### DIFF
--- a/b_synth/b_synth.ttl.in
+++ b/b_synth/b_synth.ttl.in
@@ -70,6 +70,12 @@
 		lv2:name "Right Output" ;
 		pg:group pg:StereoGroup;
 		lv2:designation pg:right
+	], [
+		a lv2:AudioPort ,
+			lv2:OutputPort ;
+		lv2:index 4 ;
+		lv2:symbol "outD" ;
+		lv2:name "Direct Output" ;
 	];
 	@MODBRAND@
 	@MODLABEL@

--- a/b_synth/lv2.c
+++ b/b_synth/lv2.c
@@ -75,7 +75,8 @@ typedef enum {
 	B3S_MIDIIN = 0,
 	B3S_MIDIOUT,
 	B3S_OUTL,
-	B3S_OUTR
+	B3S_OUTR,
+	B3S_OUTD
 } PortIndex;
 
 typedef struct {
@@ -88,6 +89,7 @@ typedef struct {
 	LV2_Atom_Sequence*       midiout;
 	float*                   outL;
 	float*                   outR;
+	float*                   outD;
 
 	LV2_URID_Map* map;
 	setBfreeURIs  uris;
@@ -278,6 +280,7 @@ synthSound (B3S* instance, uint32_t written, uint32_t nframes, float** out)
 
 		memcpy (&out[0][written], &b3s->bufL[0][b3s->boffset], nread * sizeof (float));
 		memcpy (&out[1][written], &b3s->bufL[1][b3s->boffset], nread * sizeof (float));
+		memcpy (&b3s->outD[written], &b3s->bufC[b3s->boffset], nread * sizeof (float));
 
 		written += nread;
 		b3s->boffset += nread;
@@ -1104,6 +1107,9 @@ connect_port (LV2_Handle instance,
 			break;
 		case B3S_OUTR:
 			b3s->outR = (float*)data;
+			break;
+		case B3S_OUTD:
+			b3s->outD = (float*)data;
 			break;
 	}
 }

--- a/b_synth/lv2.c
+++ b/b_synth/lv2.c
@@ -156,6 +156,8 @@ mainConfig (ConfigContext* cfg)
 		return 1;
 	} else if (strcasecmp (cfg->name, "jack.out.right") == 0) {
 		return 1;
+	} else if (strcasecmp (cfg->name, "jack.out.direct") == 0) {
+		return 1;
 	}
 	return 0;
 }

--- a/cfg/default.cfg
+++ b/cfg/default.cfg
@@ -65,6 +65,7 @@
 ## a regular expression to autoconnect to
 #jack.out.left=
 #jack.out.right=
+#jack.out.direct=
 ##
 ## this is only used of jack.out.* are unset:
 ## by default the organ connects to the first two physical outputs:

--- a/src/main.c
+++ b/src/main.c
@@ -83,9 +83,10 @@ static const char* templateProgrammeFile = SHAREDIR "/pgm/default.pgm";
 static char* defaultConfigFile    = NULL;
 static char* defaultProgrammeFile = NULL;
 
-#define AUDIO_CHANNELS (2)
+#define AUDIO_CHANNELS (3)
 #define CHN_LEFT (0)
 #define CHN_RIGHT (1)
+#define CHN_DIRECT (2)
 
 #ifdef HAVE_ASEQ
 int aseq_stop = 0;
@@ -267,7 +268,7 @@ jack_audio_callback (jack_nframes_t nframes, void* arg)
 
 			const float* horn[2] = { bufH[0], bufH[1] };
 			const float* drum[2] = { bufD[0], bufD[1] };
-			float*       out[2]  = { bufJ[0], bufJ[1] };
+			float*       out[3]  = { bufJ[0], bufJ[1], bufC };
 
 			convolve (horn, out, 2, BUFFER_SIZE_SAMPLES);
 			mixdown (out, drum, AUDIO_CHANNELS, BUFFER_SIZE_SAMPLES);
@@ -640,6 +641,7 @@ static const ConfigDoc doc[] = {
 	{ "jack.connect", CFG_TEXT, "\"system:playback_\"", "Auto connect both audio-ports to a given regular-expression. This setting is ignored if either of jack.out.{left|right} is specified.", INCOMPLETE_DOC },
 	{ "jack.out.left", CFG_TEXT, "\"\"", "Connect left-output to this jack-port (exact name)", INCOMPLETE_DOC },
 	{ "jack.out.right", CFG_TEXT, "\"\"", "Connect right-output to this jack-port (exact name)", INCOMPLETE_DOC },
+	{ "jack.out.direct", CFG_TEXT, "\"\"", "Connect direct-output (no whirl) to this jack-port (exact name)", INCOMPLETE_DOC },
 	DOC_SENTINEL
 };
 
@@ -673,6 +675,10 @@ mainConfig (ConfigContext* cfg)
 		ack++;
 		free (jack_port[CHN_RIGHT]);
 		jack_port[CHN_RIGHT] = strdup (cfg->value);
+	} else if (strcasecmp (cfg->name, "jack.out.direct") == 0) {
+		ack++;
+		free (jack_port[CHN_DIRECT]);
+		jack_port[CHN_DIRECT] = strdup (cfg->value);
 	}
 	return ack;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -98,7 +98,7 @@ static char* jack_ports = NULL;
 static char* jack_port[AUDIO_CHANNELS];
 
 static const char* portnames[AUDIO_CHANNELS] = {
-	"out_left", "out_right"
+	"out_left", "out_right", "out_direct"
 };
 
 static const char* jack_client_name = "setBfree";
@@ -271,7 +271,7 @@ jack_audio_callback (jack_nframes_t nframes, void* arg)
 			float*       out[3]  = { bufJ[0], bufJ[1], bufC };
 
 			convolve (horn, out, 2, BUFFER_SIZE_SAMPLES);
-			mixdown (out, drum, AUDIO_CHANNELS, BUFFER_SIZE_SAMPLES);
+			mixdown (out, drum, 2, BUFFER_SIZE_SAMPLES);
 #else
 			whirlProc (inst.whirl, bufC, bufJ[0], bufJ[1], BUFFER_SIZE_SAMPLES);
 #endif
@@ -279,9 +279,10 @@ jack_audio_callback (jack_nframes_t nframes, void* arg)
 
 		int nread = MIN (nremain, (BUFFER_SIZE_SAMPLES - boffset));
 
-		for (i = 0; i < AUDIO_CHANNELS; i++) {
+		for (i = 0; i < 2; i++) {
 			memcpy (&out[i][written], &bufJ[i][boffset], nread * sizeof (float));
 		}
+		memcpy (&out[CHN_DIRECT][written], &bufC[boffset], nread * sizeof (float));
 		written += nread;
 		boffset += nread;
 	}
@@ -315,10 +316,17 @@ static int
 open_jack (void)
 {
 	int i;
-	j_client = jack_client_open (jack_client_name, JackNullOption, NULL);
+	jack_status_t status;
+	j_client = jack_client_open (jack_client_name, JackNoStartServer, &status);
 
 	if (!j_client) {
-		fprintf (stderr, "could not connect to jack.\n");
+		fprintf (stderr, "could not connect to jack. status=0x%x\n", status);
+		if (status & JackServerFailed) {
+			fprintf (stderr, "Unable to connect to JACK server\n");
+		}
+		if (status & JackServerError) {
+			fprintf (stderr, "JACK server error\n");
+		}
 		return (1);
 	}
 

--- a/ui/desc.h
+++ b/ui/desc.h
@@ -10,16 +10,17 @@ static const RtkLv2Description _plugin = {
 	, 0 // uint32_t dsp_descriptor_id
 	, 0 // uint32_t gui_descriptor_id
 	, "setBfree DSP Tonewheel Organ" // const char *plugin_human_id
-	, (const struct LV2Port[4])
+	, 	(const struct LV2Port[5])
 	{
 		{ "control", MIDI_IN, nan, nan, nan, "MIDI In"},
 		{ "notify", MIDI_OUT, nan, nan, nan, "MIDI Out"},
 		{ "outL", AUDIO_OUT, nan, nan, nan, "Left Output"},
 		{ "outR", AUDIO_OUT, nan, nan, nan, "Right Output"},
+		{ "outD", AUDIO_OUT, nan, nan, nan, "Direct Output"},
 	}
-	, 4 // uint32_t nports_total
+	, 5 // uint32_t nports_total
 	, 0 // uint32_t nports_audio_in
-	, 2 // uint32_t nports_audio_out
+	, 3 // uint32_t nports_audio_out
 	, 1 // uint32_t nports_midi_in
 	, 1 // uint32_t nports_midi_out
 	, 0 // uint32_t nports_atom_in


### PR DESCRIPTION
I was trying to do what @organplayerjosef at #94 already suggested but did need to go a little deeper than expected.

The setBfreeUI works fine for me. But setBfree always segfaults sadly, both for original from `master` branch and also with this modification:

```
$ pw-jack src/setBfree
init.. Audio : Segmentation fault         (core dumped) pw-jack src/setBfree
```

So i guess there is an issue with my computer maybe. Therefore -and cause i added some debug output code to `open_jack()`- this is a draft PR: please not merge but maybe test at your side whether setBfree is working.

Thanks!