### PR TITLE
Add a compile-time option for setting drawbars to fractional levels via MIDI

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,6 +64,10 @@ else
   LOADLIBES+=`$(PKG_CONFIG) --libs jack`
 endif
 
+ifeq ($(MIDI_CONTINUOUS_DRAWBARS),1)
+  override CFLAGS+=-DMIDI_CONTINUOUS_DRAWBARS
+endif
+
 ifeq ($(shell $(PKG_CONFIG) --exists sndfile \
 	&& test -f /usr/include/zita-convolver.h -o -f /usr/local/include/zita-convolver.h \
 	&& echo yes), $(ENABLE_CONVOLUTION))

--- a/src/tonegen.c
+++ b/src/tonegen.c
@@ -276,7 +276,7 @@ initValues (struct b_tonegen* t)
 	t->percEnabled   = FALSE;
 
 	t->percTriggerBus  = 8;
-	t->percTrigRestore = 0;
+	t->percTrigRestore = 0.0;
 
 	t->percFastDecaySeconds = 1.0;
 	t->percSlowDecaySeconds = 4.0;
@@ -1571,7 +1571,7 @@ setPercussionEnabled (struct b_tonegen* t, int isEnabled)
 		t->newRouting &= ~RT_PERC;
 		if (-1 < t->percTriggerBus) {
 			t->drawBarGain[t->percTriggerBus] =
-			    t->drawBarLevel[t->percTriggerBus][t->percTrigRestore];
+			    t->percTrigRestore / 8.0;
 			t->drawBarChange = 1;
 		}
 	}
@@ -2492,25 +2492,23 @@ initEnvelopes (struct b_tonegen* t)
 }
 
 /**
- * Installs the setting for the drawbar on the given bus. The gain value is
- * fetched from the drawBarLevel table where the bus is the row index and the
- * setting is the column index.
+ * Installs the setting for the drawbar on the given bus.
  *
  * @param bus      The bus (0--26) for which the drawbar is set.
  * @param setting  The position setting (0--8) of the drawbar.
  */
 static void
-setDrawBar (struct b_tonegen* t, int bus, unsigned int setting)
+setDrawBar (struct b_tonegen* t, int bus, float setting)
 {
 	assert ((0 <= bus) && (bus < NOF_BUSES));
-	assert ((0 <= setting) && (setting < 9));
+	assert ((0.0 <= setting) && (setting <= 8.0));
 	t->drawBarChange = 1;
 	if (bus == t->percTriggerBus) {
 		t->percTrigRestore = setting;
 		if (t->percEnabled)
 			return;
 	}
-	t->drawBarGain[bus] = t->drawBarLevel[bus][setting];
+	t->drawBarGain[bus] = setting / 8.0;
 }
 
 /**
@@ -2551,9 +2549,9 @@ setDrawBars (void* inst, unsigned int manual, unsigned int setting[])
 /*
  * Note that the drawbar controllers are inverted so that fader-like
  * controllers work in reverse, like real drawbars. This means that
- * a MIDI controller value of 0 is max and 127 is min. Also note that
- * the controller values are quantized into 0, ... 8 to correspond to
- * the nine discrete positions of the original drawbar system.
+ * a MIDI controller value of 0 is max and 127 is min. The controller
+ * values are scaled into 0, ... 8 but are not quantized to correspond
+ * to the nine discrete positions of the original drawbar system.
  *
  */
 
@@ -2561,7 +2559,7 @@ static void
 setMIDIDrawBar (struct b_tonegen* t, int bus, unsigned char v)
 {
 	int val = 127 - v;
-	setDrawBar (t, bus, rint (val * 8.0 / 127.0));
+	setDrawBar (t, bus, val * 8.0 / 127.0);
 }
 
 static void
@@ -2784,9 +2782,6 @@ initToneGenerator (struct b_tonegen* t, void* m)
 	for (i = 0; i < NOF_BUSES; ++i) {
 		int j;
 		t->drawBarGain[i] = 0;
-		for (j = 0; j < 9; ++j) {
-			t->drawBarLevel[i][j] = 0;
-		}
 	}
 	for (i                   = 0; i < MAX_KEYS; ++i)
 		t->activeKeys[i] = 0;
@@ -2839,16 +2834,6 @@ initToneGenerator (struct b_tonegen* t, void* m)
 #endif /* KEYCOMPRESSION */
 
 	initEnvelopes (t);
-
-	/* Initialise drawbar gain values */
-
-	for (i = 0; i < NOF_BUSES; i++) {
-		int setting;
-		for (setting = 0; setting < 9; setting++) {
-			float u                     = (float)setting;
-			t->drawBarLevel[i][setting] = u / 8.0;
-		}
-	}
 
 #if 1
 	/* Gives the drawbars a temporary initial value */

--- a/src/tonegen.c
+++ b/src/tonegen.c
@@ -2785,7 +2785,6 @@ initToneGenerator (struct b_tonegen* t, void* m)
 	t->percIsSoft = t->percIsFast = 0;
 	t->percEnvGain                = 0;
 	for (i = 0; i < NOF_BUSES; ++i) {
-		int j;
 		t->drawBarGain[i] = 0;
 	}
 	for (i                   = 0; i < MAX_KEYS; ++i)

--- a/src/tonegen.c
+++ b/src/tonegen.c
@@ -2549,17 +2549,22 @@ setDrawBars (void* inst, unsigned int manual, unsigned int setting[])
 /*
  * Note that the drawbar controllers are inverted so that fader-like
  * controllers work in reverse, like real drawbars. This means that
- * a MIDI controller value of 0 is max and 127 is min. The controller
- * values are scaled into 0, ... 8 but are not quantized to correspond
- * to the nine discrete positions of the original drawbar system.
+ * a MIDI controller value of 0 is max and 127 is min. Also note that
+ * the controller values are quantized into 0, ... 8 to correspond to
+ * the nine discrete positions of the original drawbar system,
+ * unless MIDI_CONTINUOUS_DRAWBARS is defined.
  *
  */
 
 static void
 setMIDIDrawBar (struct b_tonegen* t, int bus, unsigned char v)
 {
-	int val = 127 - v;
-	setDrawBar (t, bus, val * 8.0 / 127.0);
+	float setting = (127 - v) * 8.0 / 127.0;
+#ifdef MIDI_CONTINUOUS_DRAWBARS
+	setDrawBar (t, bus, setting);
+#else
+	setDrawBar (t, bus, rint (setting));
+#endif /* MIDI_CONTINUOUS_DRAWBARS */
 }
 
 static void

--- a/src/tonegen.h
+++ b/src/tonegen.h
@@ -304,13 +304,6 @@ struct b_tonegen {
 	float drawBarGain[NOF_BUSES];
 
 	/**
- * The drawBarLevel table holds the possible drawbar amplification values
- * for all drawbars and settings. When a drawbar change is applied, the
- * appropriate value is copied from the table and installed in drawBarGain[].
- */
-	float drawBarLevel[NOF_BUSES][9];
-
-	/**
  * The drawBarChange flag is set by the routine that effectuates a drawbar
  * change. The oscGenerateFragment routine then checks the flag, computes
  * new composed gain values, and resets the flag.
@@ -334,7 +327,7 @@ struct b_tonegen {
  * holds the drawbar setting to restore to the trigger bus once
  * percussion is disabled.
  */
-	int percTrigRestore;
+	float percTrigRestore;
 
 	int percIsSoft; /**< Runtime toggle */
 	int percIsFast; /**< Runtime toggle */


### PR DESCRIPTION
This PR adds a compile-time option that allows drawbars to be set to fractional levels via MIDI, rather than quantizing the levels to 0-8. This is useful for subtly adjusting overtones during long notes. If the new option is unset (the default), the PR does not change the synth's behaviour or sound.

The `drawBarLevel` lookup table, which is used for converting a level 0-8 to a gain 0.0-1.0, is removed, as the conversion can easily be done on the fly. The drawbar level temporarily stored in `percTrigRestore` is converted to a float. These changes allow quantized or unquantized drawbar levels to be handled in the same way.